### PR TITLE
Fix issue with unintended activation of pretty lua when other files a…

### DIFF
--- a/Pretty Lua.py
+++ b/Pretty Lua.py
@@ -264,11 +264,13 @@ class PrettyLuaListener(ViewEventListener):
         if not active_window:
             return
 
-        is_syntax_lua = "Lua" in self.view.settings().get("syntax")
-        is_extension_lua = active_window.extract_variables()["file_extension"] == "lua"
+        file_name = self.view.file_name()
+        if not file_name.endswith(".lua"):
+            return
 
-        if PrettyLua.format_on_save and (is_syntax_lua or is_extension_lua):
-            self.view.run_command("pretty_lua")
+        view = active_window.find_open_file(file_name)
+        if view:
+            view.run_command("pretty_lua")
 
     def on_close(self):
         view_id = self.view.id()


### PR DESCRIPTION
When you modify any file and leave auto-save to activate when you move to another view that is of `.lua` extension, Pretty Lua erroneously activates in the other file producing a silly error.

I am new to this repository and using Pretty Lua, so I am not sure if the code is properly indented.

GIF Example:
![dfdsg](https://github.com/aerobounce/Sublime-Pretty-Lua/assets/28090948/5436594c-71e1-4b4d-a90f-597cab123b91)

![image](https://github.com/aerobounce/Sublime-Pretty-Lua/assets/28090948/564d0cd0-9e89-4e40-82d1-625e875c2ded)
